### PR TITLE
fix travis ci to test against official ansible, add  excluded list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,11 +48,19 @@ before_install:
       liststr=./*.yml;
       list=($liststr);
 
+      excludedList=("./vm_create_existingvnet_deployjavaapp.yml")
       echo start = $start, end = $end, list_lenth = ${#list[@]};
 
       for (( i = $start; i < $end; i++ )); do	
         if [ "$i" -lt "${#list[@]}" ]; then
-          if [ "${list[$i]}" != "./vm_create_existingvnet_deployjavaapp.yml" ]; then
+          excluded=false;
+          for item in ${excludedList[*]}; do
+            if [ "${list[$i]}" == "$item" ]; then
+              exclued=true;
+              break;
+            fi
+          done;
+          if [ "$excluded" == false ]; then
             run_test ${list[$i]};	
           fi
         fi
@@ -86,3 +94,5 @@ script:
 notifications:
   email:
     - yungez@microsoft.com
+    - yuwzho@microsoft.com
+    - zikalino@microsoft.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,5 +81,3 @@ script:
 notifications:
   email:
     - yungez@microsoft.com
-    - yuwzho@microsoft.com
-    - zikalino@microsoft.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ before_install:
           excluded=false;
           for item in ${excludedList[*]}; do
             if [ "${list[$i]}" == "$item" ]; then
-              exclued=true;
+              excluded=true;
               break;
             fi
           done;

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ before_install:
         fi
       done;
 
-      subfolders="$(ls -d */)";
+      subfolders=($(ls -d */));
 
       for (( i = $start; i< $end; i++ )); do
         if [ "$i" -lt "${#subfolders[@]}" ]; then
@@ -70,7 +70,7 @@ before_install:
           fi
         else
           foldername=${#subfolders[@]};
-          files="$(ls $foldername)";
+          files=($(ls $foldername));
           for (( i = start; i < $end; i++ )); do
             run_test ${#files[@]};
           done;

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,33 @@ before_install:
       echo start = $start, end = $end, list_lenth = ${#list[@]};
 
       for (( i = $start; i < $end; i++ )); do	
-        if [ "$i" -lt "${#list[@]}" ]; then	
-          run_test ${list[$i]};	
-        fi	
+        if [ "$i" -lt "${#list[@]}" ]; then
+          if [ "${list[$i]}" != "./vm_create_existingvnet_deployjavaapp.yml" ]; then
+            run_test ${list[$i]};	
+          fi
+        fi
       done;
+
+      subfolders="$(ls -d */)";
+
+      for (( i = $start; i< $end; i++ )); do
+        if [ "$i" -lt "${#subfolders[@]}" ]; then
+          if [ "${subfolders[$i]}" == "vmss/" ]; then
+            # run vmss test in specific order
+            run_test "./vmss/vmss-create.yml";
+            run_test "./vmss/vmss-setup-deploy.yml";
+            run_test "./vmss/vmss-scale-out.yml";
+          fi
+        else
+          foldername=${#subfolders[@]};
+          files="$(ls $foldername)";
+          for (( i = start; i < $end; i++ )); do
+            run_test ${#files[@]};
+          done;
+        fi
+
+      done;
+
     }
 
 install:
@@ -65,6 +88,8 @@ install:
   - apt-cache policy docker-ce
   - sudo apt-get install -y docker-ce
   - sudo usermod -aG docker ${USER}
+  - sudo apt-get install -y default-jdk
+  - sudo apt-get install -y maven
 
   - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible[azure]; else pip
     install ansible[azure]==$ANSIBLE_VERSION; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,22 +13,12 @@ env:
     - ANSIBLE_VERSION=latest
     #- ANSIBLE_VERSION=2.4.2.0
   matrix:
-    - id="devel-1"
-    - id="devel-2"
-    - id="devel-3"
-    - id="devel-4"
-    - id="devel-5"
-    - id="devel-azure-preview-modules"
-    - id="2.6-stable-1"
-    - id="2.6-stable-2"
-    - id="2.6-stable-3"
-    - id="2.6-stable-4"
-    - id="2.6-stable-5"
-    - id="2.5-stable-1"
-    - id="2.5-stable-2"
-    - id="2.5-stable-3"
-    - id="2.5-stable-4"
-    - id="2.5-stable-5"
+    - id=1
+    - id=2
+    - id=3
+    - id=4
+    - id=5
+    - id=6
 
 before_install:
   - sudo apt-get update -qq
@@ -52,25 +42,19 @@ before_install:
 
 
   - scan_test() {
-        if [ $id == "devel-1" ]; then
-          run_test mysql_create.yml;
-          run_test postgresql_create.yml;
-          run_test sql_create.yml;
-        fi;
-        if [ $id == "devel-2" ]; then
-          run_test aci_create_with_acr.yml;
-        fi;
-        if [ $id == "devel-3" ]; then
-          run_test vm_create.yml;
-          run_test vm_create_ssh.yml;
-        fi;
-        if [ $id == "devel-4" ]; then
-          run_test networkinterface_with_virtualnetwork_in_another_resource_group.yml;
-        fi;
-        if [ $id == "devel-5" ]; then
-          echo "no tests";
-        fi;
+      end=$((id * number_per_job));
+      start=$((end - number_per_job));
 
+      liststr=./*.yml;
+      list=($liststr);
+
+      echo start = $start, end = $end, list_lenth = ${#list[@]};
+
+      for (( i = $start; i < $end; i++ )); do	
+        if [ "$i" -lt "${#list[@]}" ]; then	
+          run_test ${list[$i]};	
+        fi	
+      done;
     }
 
 install:
@@ -81,19 +65,12 @@ install:
   - apt-cache policy docker-ce
   - sudo apt-get install -y docker-ce
   - sudo usermod -aG docker ${USER}
-#  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible[azure]; else pip
-#    install ansible[azure]==$ANSIBLE_VERSION; fi
-#  - pip install ansible[azure]==2.6.0.rc3
-#  - pip install ansible[azure]==2.5.0
-  - git clone https://github.com/ansible/ansible.git
-  - pip install -r ./ansible/requirements.txt
-  - pip install -r ./ansible/packaging/requirements/requirements-azure.txt 
-  - cd ansible
-  - source ./hacking/env-setup
-  - cd ..
+
+  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible[azure]; else pip
+    install ansible[azure]==$ANSIBLE_VERSION; fi
   - ansible --version
-#  - ansible-galaxy install Azure.azure_preview_modules
-#  - pip install -I -r ~/.ansible/roles/Azure.azure_preview_modules/files/requirements-azure.txt
+  - ansible-galaxy install Azure.azure_preview_modules
+  - pip install -I -r ~/.ansible/roles/Azure.azure_preview_modules/files/requirements-azure.txt
   - pip install docker
   - pip freeze
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,26 +58,6 @@ before_install:
         fi
       done;
 
-      subfolders=($(ls -d */));
-
-      for (( i = $start; i< $end; i++ )); do
-        if [ "$i" -lt "${#subfolders[@]}" ]; then
-          if [ "${subfolders[$i]}" == "vmss/" ]; then
-            # run vmss test in specific order
-            run_test "./vmss/vmss-create.yml";
-            run_test "./vmss/vmss-setup-deploy.yml";
-            run_test "./vmss/vmss-scale-out.yml";
-          fi
-        else
-          foldername=${#subfolders[@]};
-          files=($(ls $foldername));
-          for (( i = start; i < $end; i++ )); do
-            run_test ${#files[@]};
-          done;
-        fi
-
-      done;
-
     }
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
       file=$1;
       test_name=${file##./};
       test_name=${test_name%%.yml};
-      resource_group="${test_name}$(date +%s)";
+      resource_group="sampleplaybook$(date +%s)";
       echo Run playbook $file;
 
       travis_wait 50 ansible-playbook $file --extra-vars "{\"azure_subscription_id\":$AZURE_SUBSCRIPTION_ID,\"azure_tenant\":$AZURE_TENANT,\"azure_client_id\":$AZURE_CLIENT_ID,\"resource_group_name\":$resource_group}";
@@ -48,7 +48,7 @@ before_install:
       liststr=./*.yml;
       list=($liststr);
 
-      excludedList=("./vm_create_existingvnet_deployjavaapp.yml")
+      excludedList=("./vm_create_existingvnet_deployjavaapp.yml");
       echo start = $start, end = $end, list_lenth = ${#list[@]};
 
       for (( i = $start; i < $end; i++ )); do	

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python: '2.7'
 
 branches:
   only:
-    - master
+    - fix-ci
 
 env:
   global:

--- a/__helpers/__delete_test_resource_group.yml
+++ b/__helpers/__delete_test_resource_group.yml
@@ -8,6 +8,6 @@
   tasks:
   - name: delete test resource group
     azure_rm_resourcegroup:
-      name: '{{resource_group_name}}'
+      name: "{{ resource_group_name }}"
       force: True
       state: absent

--- a/keyvault_create.yml
+++ b/keyvault_create.yml
@@ -1,8 +1,8 @@
 # Description
 # ===========
 # This playbook create a Key Vault , then add key and secret in it.
-# azure_rm_keyvault module is not available in v2.4, but in azure_preview_modules role,
-# so you need to run "ansible-galaxy install Azure.azure_preview_modules" to install the role to get lastest Ansible modules.
+# This playbook requires Ansible version >= 2.5, and azure_preview_modules role
+# You need to run "ansible-galaxy install Azure.azure_preview_modules" to install the role to get lastest Ansible modules.
 
 ---
 - hosts: localhost
@@ -19,6 +19,10 @@
     resource_group: "{{ resource_group_name }}"
     location: eastus
     keyvault_name: keyvault{{ rpfx }}
+  
+  roles:
+    - Azure.azure_preview_modules
+
   tasks:
     - name: set facts
       set_fact:

--- a/keyvault_create.yml
+++ b/keyvault_create.yml
@@ -9,7 +9,7 @@
   tasks:
     - name: Prepare random postfix
       set_fact:
-        rpfx: "{{ 1000 | random }}"
+        rpfx: "{{ 10000 | random }}"
       run_once: yes
 
 - hosts: localhost
@@ -18,7 +18,7 @@
   vars:
     resource_group: "{{ resource_group_name }}"
     location: eastus
-    keyvault_name: keyvault{{ rpfx }}    
+    keyvault_name: keyvault{{ rpfx }}
   tasks:
     - name: set facts
       set_fact:

--- a/vm_create_existingvnet_deployjavaapp.yml
+++ b/vm_create_existingvnet_deployjavaapp.yml
@@ -103,14 +103,14 @@
       wait_for:
         port: 22
         host: '{{ output.ansible_facts.azure_vm.properties.networkProfile.networkInterfaces[0].properties.ipConfigurations[0].properties.privateIPAddress }}'
-        timeout: 600 
+        timeout: 600
 
     - name: Git Clone
       git:
         repo: "{{ repo_url }}"
         dest: "{{ workspace }}"
 
-    - name: build sample app      
+    - name: build sample app
       shell: mvn package chdir="{{ workspace }}"
 
     - block:

--- a/vm_create_existingvnet_deployjavaapp.yml
+++ b/vm_create_existingvnet_deployjavaapp.yml
@@ -16,7 +16,7 @@
   connection: local
   gather_facts: true
   vars:
-    resource_group_vm: {{ resource_group_name }}
+    resource_group_vm: "{{ resource_group_name }}"
     resource_group_vnet: rg_yungezpvnet1
     vnet_name: yungezpvnet1
     subnet_name: yungezsnet1

--- a/vm_create_existingvnet_deployjavaapp.yml
+++ b/vm_create_existingvnet_deployjavaapp.yml
@@ -16,7 +16,7 @@
   connection: local
   gather_facts: true
   vars:
-    resource_group_vm: rg_yungezpvm1
+    resource_group_vm: {{ resource_group_name }}
     resource_group_vnet: rg_yungezpvnet1
     vnet_name: yungezpvnet1
     subnet_name: yungezsnet1

--- a/vm_create_windows.yml
+++ b/vm_create_windows.yml
@@ -2,14 +2,19 @@
 # ===========
 # This playbook creates an Azure Windows VM with public IP. It also cobnfigures the machine to be accessible via Ansible using WinRM.
 # This playbook originally comes from @jborean93 (https://github.com/jborean93/ansible-win-demos)
-
+- hosts: localhost
+  tasks:
+    - name: Prepare random postfix
+      set_fact:
+        rpfx: "{{ 100000 | random }}"
+      run_once: yes
 
 - name: provision new azure host
   hosts: localhost
   connection: local
   vars:
     resource_group: "{{ resource_group_name }}"
-    vm_name: zimswintestvm
+    vm_name: zimswintestvm{{ rpfx }}
     vm_user: azureuser
     vm_password: MyPassword123!!!
     location: eastus
@@ -21,55 +26,55 @@
   tasks:
   - name: create Azure resource group
     azure_rm_resourcegroup:
-      name: '{{resource_group}}'
+      name: "{{ resource_group }}"
       location: '{{ location }}'
       state: present
 
   - name: create Azure virtual network in resource group
     azure_rm_virtualnetwork:
-      name: '{{vm_name}}'
-      resource_group: '{{resource_group}}'
+      name: "{{ vm_name }}"
+      resource_group: "{{ resource_group }}"
       address_prefixes_cidr:
       - 10.1.0.0/16
       state: present
   
   - name: create Azure subnet in virtualnetwork
     azure_rm_subnet:
-      name: '{{vm_name}}'
+      name: '{{ vm_name }}'
       state: present
-      virtual_network_name: '{{vm_name}}'
-      resource_group: '{{resource_group}}'
+      virtual_network_name: "{{ vm_name }}"
+      resource_group: "{{ resource_group }}"
       address_prefix_cidr: 10.1.0.0/24
 
   - name: create Azure storage account
     azure_rm_storageaccount:
-      name: '{{vm_name}}'
-      resource_group: '{{resource_group}}'
+      name: '{{ vm_name }}'
+      resource_group: "{{ resource_group }}"
       account_type: Standard_LRS
 
   - name: provision new Azure virtual host
     azure_rm_virtualmachine:
       admin_username: '{{ vm_user }}'
-      admin_password: '{{vm_password}}'
+      admin_password: "{{ vm_password }}"
       os_type: Windows
       image:
         offer: WindowsServer
         publisher: MicrosoftWindowsServer
         sku: 2016-Datacenter
         version: latest
-      name: '{{vm_name}}'
-      resource_group: '{{resource_group}}'
+      name: "{{ vm_name }}"
+      resource_group: "{{ resource_group }}"
       state: present
       vm_size: Standard_D1
-      storage_account_name: '{{vm_name}}'
-      virtual_network_name: '{{vm_name}}'
-      subnet_name: '{{vm_name}}'
+      storage_account_name: "{{ vm_name }}"
+      virtual_network_name: "{{ vm_name }}"
+      subnet_name: "{{ vm_name }}"
 
   - name: create Azure vm extension to enable HTTPS WinRM listener
     azure_rm_virtualmachine_extension:
       name: winrm-extension
-      resource_group: '{{resource_group}}'
-      virtual_machine_name: '{{vm_name}}'
+      resource_group: "{{ resource_group }}"
+      virtual_machine_name: "{{ vm_name }}"
       publisher: Microsoft.Compute
       virtual_machine_extension_type: CustomScriptExtension
       type_handler_version: 1.9

--- a/vm_create_windows.yml
+++ b/vm_create_windows.yml
@@ -14,7 +14,7 @@
   connection: local
   vars:
     resource_group: "{{ resource_group_name }}"
-    vm_name: zimswintestvm{{ rpfx }}
+    vm_name: wintestvm{{ rpfx }}
     vm_user: azureuser
     vm_password: MyPassword123!!!
     location: eastus


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
fix below issues:
1. use installed ansible in travis.yml, instead of source.
2. comment out vm_create_existingvnet_deployjavaapp.yml from CI, because  this playbook create a vm with private ip, then try to install java on that vm. This playbook cannot be  tested via CI, but manual testing.
3. fix syntax issue in some yaml

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
- [ ] Yes
- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix


## How to Test
*  Install ansible

```bash
$ pip install ansible[azure]
```

*  [Optional] Install ansible role

```bash
$ ansible-galaxy install Azure.azure_preview_modules
$ pip install -r ~/.ansible/roles/Azure.azure_preview_modules/files/requirements-azure.txt
```

*  Get the sample playbook

```
git clone https://github.com/Azure-Samples/ansible-playbooks.git
cd ansible-playbooks
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```bash
ansible-playbook <filename>.yml
```

## What to Check
Verify that the playbook is successfully run.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
