### PR TITLE
fix ansible shell background run issue

### DIFF
--- a/vmss/vmss-setup-deploy.yml
+++ b/vmss/vmss-setup-deploy.yml
@@ -36,7 +36,7 @@
     - name: Build sample app
       shell: mvn package chdir="{{ workspace }}/complete"
 
-- name: Install JRE on Ubuntu 16.04
+- name: Install JRE on VMSS
   hosts: scalesethosts
   become: yes
   vars:
@@ -58,4 +58,7 @@
       mode: 0755
 
   - name: Start the app
-    shell: java -jar "/home/{{ admin_username }}/helloworld.jar" 2>&1 &
+    shell: java -jar "/home/{{ admin_username }}/helloworld.jar" >/dev/null 2>&1 &
+    async: 5000
+    poll: 0
+


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* ...
fixing bug, when ansible run shell as background, it failed to start, use async mode to run it.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix

## How to Test
*  Install ansible

```bash
$ pip install ansible[azure]
```

*  [Optional] Install ansible role

```bash
$ ansible-galaxy install Azure.azure_preview_modules
$ pip install -r ~/.ansible/roles/Azure.azure_preview_modules/files/requirements-azure.txt
```

*  Get the sample playbook

```
git clone https://github.com/Azure-Samples/ansible-playbooks.git
cd ansible-playbooks
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```bash
ansible-playbook <filename>.yml
```

## What to Check
Verify that the playbook is successfully run.

## Other Information
<!-- Add any other helpful information that may be needed here. -->
