### PR TITLE
replaced deprecated azure load balancer module parameters

### DIFF
--- a/vmss/vmss-create.yml
+++ b/vmss/vmss-create.yml
@@ -4,7 +4,7 @@
 # It also requires following env variables to be defined:
 # - VMSS_ADMIN_USERNAME
 # - VMSS_ADMIN_PASSWORD
-# This sample requires Ansible 2.6 
+# This sample requires Ansible 2.9
 
 ---
 - hosts: localhost
@@ -50,25 +50,37 @@
 
     - name: Create a load balancer
       azure_rm_loadbalancer:
+        resource_group: "{{ resource_group }}"
         name: "{{ vmss_name }}lb"
         location: "{{ location }}"
-        resource_group: "{{ resource_group }}"
-        public_ip: "{{ vmss_name }}"
-        probe_protocol: Tcp
-        probe_port: 8080
-        probe_interval: 10
-        probe_fail_count: 3
-        protocol: Tcp
-        load_distribution: Default
-        frontend_port: 80
-        backend_port: 8080
-        idle_timeout: 4
-        natpool_frontend_port_start: 50000
-        natpool_frontend_port_end: 50040
-        natpool_backend_port: 22
-        natpool_protocol: Tcp
+        frontend_ip_configurations:
+          - name: "{{ vmss_name }}front-config"
+            public_ip_address: "{{ vmss_name }}"
+        backend_address_pools:
+          - name: "{{ vmss_name }}backend-pool"
+        probes:
+          - name: "{{ vmss_name }}prob0"
+            port: 8080
+            interval: 10
+            fail_count: 3
+        inbound_nat_pools:
+          - name: "{{ vmss_name }}nat-pool"
+            frontend_ip_configuration_name: "{{ vmss_name }}front-config"
+            protocol: Tcp
+            frontend_port_range_start: 50000
+            frontend_port_range_end: 50040
+            backend_port: 22
+        load_balancing_rules:
+          - name: "{{ vmss_name }}lb-rules"
+            frontend_ip_configuration: "{{ vmss_name }}front-config"
+            backend_address_pool: "{{ vmss_name }}backend-pool"
+            frontend_port: 80
+            backend_port: 8080
+            load_distribution: Default
+            probe: "{{ vmss_name }}prob0"
 
     - name: Create VMSS
+      no_log: true
       azure_rm_virtualmachinescaleset:
         resource_group: "{{ resource_group }}"
         name: "{{ vmss_name }}"

--- a/vmss/vmss-scale-out.yml
+++ b/vmss/vmss-scale-out.yml
@@ -21,7 +21,7 @@
         format: curated
       register: output_scaleset
 
-    - name: set image fact
+    - name: Set image fact
       set_fact:
         vmss_image: "{{ output_scaleset.vmss[0].image }}"
 

--- a/vmss/vmss-scale-out.yml
+++ b/vmss/vmss-scale-out.yml
@@ -25,7 +25,7 @@
       set_fact:
         vmss_image: "{{ output_scaleset.vmss[0].image }}"
 
-    - name: Create VMSS
+    - name: Change VMSS capacity
       no_log: true
       azure_rm_virtualmachinescaleset:
         resource_group: "{{ resource_group }}"

--- a/vmss/vmss-scale-out.yml
+++ b/vmss/vmss-scale-out.yml
@@ -2,28 +2,33 @@
 # ===========
 # Use this playbook to scale up VMSS -- update number of VMs from 2 to 3.
 # Use vmss-create playbook to create VMSS first
-# This sample requires Ansible 2.6 
+# This sample requires Ansible 2.9
 
 ---
 - hosts: localhost
+  gather_facts: false
+  
   vars:
-    resource_group: "{{ resource_group_name }}"
+    resource_group: myTestRG
     vmss_name: myTestVMSS
-  tasks: 
+  
+  tasks:
+
     - name: Get scaleset info
-      azure_rm_virtualmachinescaleset_facts:
+      azure_rm_virtualmachine_scaleset_facts:
         resource_group: "{{ resource_group }}"
         name: "{{ vmss_name }}"
         format: curated
       register: output_scaleset
 
-    - name: Dump scaleset info
-      debug:
-        var: output_scaleset
-
-    - name: Modify scaleset (Change capacity to 3)
+    - name: set image fact
       set_fact:
-        body: "{{ output_scaleset.ansible_facts.azure_vmss[0] | combine({'capacity': 3}, recursive=True) }}"
+        vmss_image: "{{ output_scaleset.vmss[0].image }}"
 
-    - name: Update something in that VMSS
-      azure_rm_virtualmachinescaleset: "{{ body }}"
+    - name: Create VMSS
+      no_log: true
+      azure_rm_virtualmachinescaleset:
+        resource_group: "{{ resource_group }}"
+        name: "{{ vmss_name }}"
+        capacity: 3
+        image: "{{ vmss_image }}"


### PR DESCRIPTION
## Purpose

Replaced deprecated azure load balancer module parameters for playbook `vmss-create.yml`, per issue #243 in Azure-dev-docs.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
- [ ] Yes
- [x] No

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Documentation content changes
- [ ] Other... Please describe:

## How to Test
*  Install ansible

```bash
$ pip install ansible[azure]
```

*  [Optional] Install ansible role

```bash
$ ansible-galaxy install azure.azure_preview_modules
$ pip install -r ~/.ansible/roles/azure.azure_preview_modules/files/requirements-azure.txt
```

*  Get the sample playbook

```
git clone https://github.com/Azure-Samples/ansible-playbooks.git
cd ansible-playbooks
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```bash
ansible-playbook <filename>.yml
```

## What to Check

Verified that the playbook runs without error. I also confirmed that it creates the exact same Azure resources and configures the same settings as the prior version of the playbook.

## Other Information

`no_log` was added to the `azure_rm_virtualmachinescaleset` to prevent secrets from being output accidently.
